### PR TITLE
fix: fix blueprintjs background color

### DIFF
--- a/packages/blueprintjs-renderers/src/stories/BlueprintJsRenderers.stories.tsx
+++ b/packages/blueprintjs-renderers/src/stories/BlueprintJsRenderers.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { InteractionMode, StaticTreeDataProvider, Tree, UncontrolledTreeEnvironment } from 'react-complex-tree';
 import { longTree, shortTree } from 'demodata';
 import { renderers } from '../renderers';
-import { FocusStyleManager } from '@blueprintjs/core';
+import { Colors, FocusStyleManager } from '@blueprintjs/core';
 
 FocusStyleManager.onlyShowFocusOnTabs();
 
@@ -24,6 +24,7 @@ export default {
 
 export const BlueprintJsTree = () => (
   <div
+    style={{ background: Colors.LIGHT_GRAY5 }}
     onMouseDown={() => FocusStyleManager.onlyShowFocusOnTabs()}
     onKeyDown={() => FocusStyleManager.alwaysShowFocus()}
   >
@@ -47,6 +48,7 @@ export const BlueprintJsTree = () => (
 
 export const ShortBlueprintJsTree = () => (
   <div
+    style={{ background: Colors.LIGHT_GRAY5 }}
     onMouseDown={() => FocusStyleManager.onlyShowFocusOnTabs()}
     onKeyDown={() => FocusStyleManager.alwaysShowFocus()}
   >
@@ -70,6 +72,7 @@ export const ShortBlueprintJsTree = () => (
 
 export const BlueprintJsTreeWithClickArrowToExpand = () => (
   <div
+    style={{ background: Colors.LIGHT_GRAY5 }}
     onMouseDown={() => FocusStyleManager.onlyShowFocusOnTabs()}
     onKeyDown={() => FocusStyleManager.alwaysShowFocus()}
   >


### PR DESCRIPTION
The blueprintjs tree doesn't set a background, so [the docs suggest manually setting the background color](https://blueprintjs.com/docs/versions/4/#core/components/tree.css). Since we don't have a custom style sheet for this and we are using blueprintjs css from CDN, we just hard-code the background color to `LIGHT_GRAY5` which is the [default background color](https://github.com/palantir/blueprint/blob/9781578d1ecdc98aee5ed2c5fd18fb57859d33f0/packages/core/src/common/_color-aliases.scss#L9).

This fixes the examples not being readable when docusaurus is in dark mode.