### PR TITLE
fix: add useCallSoon hook

### DIFF
--- a/packages/core/src/controlledEnvironment/DragAndDropProvider.tsx
+++ b/packages/core/src/controlledEnvironment/DragAndDropProvider.tsx
@@ -7,6 +7,7 @@ import { useCanDropAt } from './useCanDropAt';
 import { useGetViableDragPositions } from './useGetViableDragPositions';
 import { useSideEffect } from '../useSideEffect';
 import { buildMapForTrees } from '../utils';
+import { useCallSoon } from '../useCallSoon';
 
 const DragAndDropContext = React.createContext<DragAndDropContextProps>(null as any);
 export const useDragAndDrop = () => React.useContext(DragAndDropContext);
@@ -22,6 +23,7 @@ export const DragAndDropProvider: React.FC = props => {
   const [draggingPosition, setDraggingPosition] = useState<DraggingPosition>();
   const [dragCode, setDragCode] = useState('_nodrag');
   const getViableDragPositions = useGetViableDragPositions();
+  const callSoon = useCallSoon();
 
   const resetProgrammaticDragIndexForCurrentTree = useCallback(
     (viableDragPositions: DraggingPosition[], draggingItems: TreeItem[] | undefined) => {
@@ -131,13 +133,13 @@ export const DragAndDropProvider: React.FC = props => {
       if (draggingItems && draggingPosition && environment.onDrop) {
         environment.onDrop(draggingItems, draggingPosition);
 
-        requestAnimationFrame(() => {
+        callSoon(() => {
           environment.onFocusItem?.(draggingItems[0], draggingPosition.treeId);
           resetState();
         });
       }
     },
-    [draggingItems, draggingPosition, environment, resetState]
+    [draggingItems, draggingPosition, environment, resetState, callSoon]
   );
 
   const onStartDraggingItems = useCallback(

--- a/packages/core/src/hotkeys/useHotkey.ts
+++ b/packages/core/src/hotkeys/useHotkey.ts
@@ -2,6 +2,7 @@ import { useHtmlElementEventListener } from '../useHtmlElementEventListener';
 import { useMemo, useRef } from 'react';
 import { KeyboardBindings } from '../types';
 import { useKeyboardBindings } from './useKeyboardBindings';
+import { useCallSoon } from '../useCallSoon';
 
 const elementsThatCanTakeText = ['input', 'textarea'];
 
@@ -14,6 +15,7 @@ export const useHotkey = (
 ) => {
   const pressedKeys = useRef<string[]>([]);
   const keyboardBindings = useKeyboardBindings();
+  const callSoon = useCallSoon();
 
   const possibleCombinations = useMemo(
     () => keyboardBindings[combinationName].map(combination => combination.split('+')),
@@ -74,11 +76,11 @@ export const useHotkey = (
         .reduce((a, b) => a || b, false);
 
       if (match) {
-        requestAnimationFrame(() => onHit(e));
+        callSoon(() => onHit(e));
       }
 
       pressedKeys.current = pressedKeys.current.filter(key => key !== e.key);
     },
-    [possibleCombinations, onHit, active, ...(deps ?? [])]
+    [possibleCombinations, onHit, active, callSoon, ...(deps ?? [])]
   );
 };

--- a/packages/core/src/search/SearchInput.tsx
+++ b/packages/core/src/search/SearchInput.tsx
@@ -5,6 +5,7 @@ import { useTree } from '../tree/Tree';
 import { useTreeEnvironment } from '../controlledEnvironment/ControlledTreeEnvironment';
 import { useSearchMatchFocus } from './useSearchMatchFocus';
 import { useViewState } from '../tree/useViewState';
+import { useCallSoon } from '../useCallSoon';
 
 export const SearchInput: React.FC<{
   containerRef?: HTMLElement;
@@ -13,6 +14,7 @@ export const SearchInput: React.FC<{
   const environment = useTreeEnvironment();
   useViewState();
   const isActiveTree = environment.activeTreeId === treeId;
+  const callSoon = useCallSoon();
 
   useSearchMatchFocus();
 
@@ -30,16 +32,16 @@ export const SearchInput: React.FC<{
   useHotkey(
     'abortSearch',
     () => {
-      // Without the requestAnimationFrame, hitting enter to abort
+      // Without the callSoon, hitting enter to abort
       // and then moving focus weirdly moves the selected item along
       // with the focused item.
-      requestAnimationFrame(() => {
+      callSoon(() => {
         clearSearch();
       });
     },
     isActiveTree && search !== null,
     true,
-    [search, isActiveTree]
+    [search, isActiveTree, callSoon]
   );
 
   useHtmlElementEventListener(

--- a/packages/core/src/search/useSearchMatchFocus.ts
+++ b/packages/core/src/search/useSearchMatchFocus.ts
@@ -3,16 +3,18 @@ import { useTreeEnvironment } from '../controlledEnvironment/ControlledTreeEnvir
 import { defaultMatcher } from './defaultMatcher';
 import { useSideEffect } from '../useSideEffect';
 import { useLinearItems } from '../controlledEnvironment/useLinearItems';
+import { useCallSoon } from '../useCallSoon';
 
 export const useSearchMatchFocus = () => {
   const { doesSearchMatchItem, items, getItemTitle, onFocusItem } = useTreeEnvironment();
   const { search, treeId } = useTree();
   const linearItems = useLinearItems(treeId);
+  const callSoon = useCallSoon();
 
   useSideEffect(
     () => {
       if (search && search.length > 0) {
-        requestAnimationFrame(() => {
+        callSoon(() => {
           const focusItem = linearItems.find(({ item }) =>
             (doesSearchMatchItem ?? defaultMatcher)(search, items[item], getItemTitle(items[item]))
           );
@@ -23,7 +25,7 @@ export const useSearchMatchFocus = () => {
         });
       }
     },
-    [doesSearchMatchItem, getItemTitle, linearItems, items, onFocusItem, search, treeId],
+    [doesSearchMatchItem, getItemTitle, linearItems, items, onFocusItem, search, treeId, callSoon],
     [search]
   );
 };

--- a/packages/core/src/tree/useFocusWithin.ts
+++ b/packages/core/src/tree/useFocusWithin.ts
@@ -1,5 +1,6 @@
 import { useHtmlElementEventListener } from '../useHtmlElementEventListener';
 import { useRef, useState } from 'react';
+import { useCallSoon } from '../useCallSoon';
 
 export const useFocusWithin = (
   element: HTMLElement | undefined,
@@ -9,6 +10,7 @@ export const useFocusWithin = (
 ) => {
   const [focusWithin, setFocusWithin] = useState(false);
   const isLoosingFocusFlag = useRef(false);
+  const callSoon = useCallSoon();
 
   useHtmlElementEventListener(
     element,
@@ -32,7 +34,7 @@ export const useFocusWithin = (
     () => {
       isLoosingFocusFlag.current = true;
 
-      requestAnimationFrame(() => {
+      callSoon(() => {
         if (isLoosingFocusFlag.current && !element?.contains(document.activeElement)) {
           onFocusOut?.();
           isLoosingFocusFlag.current = false;
@@ -40,7 +42,7 @@ export const useFocusWithin = (
         }
       });
     },
-    [element, onFocusOut, ...deps]
+    [element, onFocusOut, callSoon, ...deps]
   );
 
   return focusWithin;

--- a/packages/core/src/treeItem/TreeItemRenamingInput.tsx
+++ b/packages/core/src/treeItem/TreeItemRenamingInput.tsx
@@ -5,6 +5,7 @@ import { useTreeEnvironment } from '../controlledEnvironment/ControlledTreeEnvir
 import { FormHTMLAttributes, HTMLProps, InputHTMLAttributes, useRef, useState } from 'react';
 import { useHotkey } from '../hotkeys/useHotkey';
 import { useSideEffect } from '../useSideEffect';
+import { useCallSoon } from '../useCallSoon';
 
 export const TreeItemRenamingInput: React.FC<{
   itemIndex: TreeItemIndex;
@@ -15,11 +16,12 @@ export const TreeItemRenamingInput: React.FC<{
   const submitButtonRef = useRef<any>(null);
   const item = environment.items[props.itemIndex];
   const [title, setTitle] = useState(environment.getItemTitle(item));
+  const callSoon = useCallSoon();
 
   const abort = () => {
     environment.onAbortRenamingItem?.(item, treeInformation.treeId);
     setRenamingItem(null);
-    requestAnimationFrame(() => {
+    callSoon(() => {
       environment.setActiveTree(treeId);
     });
   };
@@ -27,7 +29,7 @@ export const TreeItemRenamingInput: React.FC<{
   const confirm = () => {
     environment.onRenameItem?.(item, title, treeInformation.treeId);
     setRenamingItem(null);
-    requestAnimationFrame(() => {
+    callSoon(() => {
       environment.setActiveTree(treeId);
     });
   };

--- a/packages/core/src/useCallSoon.ts
+++ b/packages/core/src/useCallSoon.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * React hook that schedules a callback to be run "soon" and will cancel the
+ * callback if it is still pending when the component is unmounted.
+ *
+ * @returns A function that can be used to schedule a deferred callback.
+ */
+export function useCallSoon(): (callback: () => void) => void {
+  // list of pending callbacks
+  const handleRef = useRef(new Array<number>());
+
+  // if the component is unmounted, cancel any pending callbacks
+  useEffect(() => {
+    // can't use handleRef.current in the cleanup function, so we have to
+    // assign it to a new variable here.
+    const handles = handleRef.current;
+    return () => handles.forEach(handle => cancelAnimationFrame(handle));
+  }, [handleRef]);
+
+  // schedule callback soon and keep handle for later cancellation
+  const callSoon = useCallback(
+    (callback: () => void) => {
+      const handle = requestAnimationFrame(() => {
+        // remove the handle from the list of pending callbacks
+        handleRef.current.splice(handleRef.current.indexOf(handle), 1);
+
+        callback();
+      });
+
+      handleRef.current.push(handle);
+    },
+    [handleRef]
+  );
+
+  return callSoon;
+}


### PR DESCRIPTION
This replaces uses of `requestAnimationFrame()` with a new `useCallSoon()` hook. This hook does the same thing but it will cancel any pending callbacks if a component is unmounted.

Fixes: https://github.com/lukasbach/react-complex-tree/issues/44