### PR TITLE
fix: use strict checks for focusedItem

### DIFF
--- a/packages/core/src/tree/useTreeKeyboardBindings.ts
+++ b/packages/core/src/tree/useTreeKeyboardBindings.ts
@@ -135,7 +135,7 @@ export const useTreeKeyboardBindings = () => {
     useCallback(
       e => {
         e.preventDefault();
-        if (viewState.focusedItem) {
+        if (viewState.focusedItem !== undefined) {
           environment.onSelectItems?.([viewState.focusedItem], treeId);
           environment.onPrimaryAction?.(environment.items[viewState.focusedItem], treeId);
         }
@@ -150,7 +150,7 @@ export const useTreeKeyboardBindings = () => {
     useCallback(
       e => {
         e.preventDefault();
-        if (viewState.focusedItem) {
+        if (viewState.focusedItem !== undefined) {
           if (viewState.selectedItems && viewState.selectedItems.includes(viewState.focusedItem)) {
             environment.onSelectItems?.(
               viewState.selectedItems.filter(item => item !== viewState.focusedItem),
@@ -185,7 +185,7 @@ export const useTreeKeyboardBindings = () => {
     'renameItem',
     useCallback(
       e => {
-        if (viewState.focusedItem) {
+        if (viewState.focusedItem !== undefined) {
           e.preventDefault();
           const item = environment.items[viewState.focusedItem];
           environment.onStartRenamingItem?.(item, treeId);


### PR DESCRIPTION
This uses strict checking against undefined for `focusedItem`. Since `focusedItem` can be a string or a number, an empty string and 0 will evaluate to false and cause keyboard shortcuts to not work for any items with an index of either of those two cases.