### PR TITLE
fix: fixes bug where cannot expand when dropping on empty children

### DIFF
--- a/packages/core/src/uncontrolledEnvironment/StaticTreeDataProvider.ts
+++ b/packages/core/src/uncontrolledEnvironment/StaticTreeDataProvider.ts
@@ -21,6 +21,9 @@ export class StaticTreeDataProvider<T = any> implements TreeDataProvider {
 
   public async onChangeItemChildren(itemId: TreeItemIndex, newChildren: TreeItemIndex[]): Promise<void> {
     this.data.items[itemId].children = newChildren;
+    if (!this.data.items[itemId].hasChildren) {
+      this.data.items[itemId].hasChildren = true;
+    }
     this.onDidChangeTreeDataEmitter.emit([itemId]);
   }
 


### PR DESCRIPTION
Usually items starts without children, so the collapse arrow is not displayed as expected. But when dragging into one of those items, adding children to them, the `hasChildren` flag is not updated, so the arrow still doesn't show up, even thought the item now have children. And then you cannot expand to see its children