### PR TITLE
add default type parameter for TreeViewState

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -167,14 +167,14 @@ export interface TreeCapabilities<T = any, C extends string = never> {
   showLiveDescription?: boolean;
 }
 
-export type IndividualTreeViewState<C extends string> = {
+export type IndividualTreeViewState<C extends string = never> = {
   selectedItems?: TreeItemIndex[];
   expandedItems?: TreeItemIndex[];
   untruncatedItems?: TreeItemIndex[];
   focusedItem?: TreeItemIndex;
 } & { [c in C]: TreeItemIndex | TreeItemIndex[] | undefined };
 
-export interface TreeViewState<C extends string> {
+export interface TreeViewState<C extends string = never> {
   [treeId: string]: IndividualTreeViewState<C> | undefined;
 }
 


### PR DESCRIPTION
Adding a type parameter without a default value is a breaking change, so when the `<C>` parameter was added, it causes typescript to raise an error for existing code that uses these types. Adding a default value of never ensures that existing code doesn't break.