### PR TITLE
Use metaKey in additional to ctrlKey during interaction

### DIFF
--- a/packages/core/src/interactionMode/ClickArrowToExpandInteractionManager.ts
+++ b/packages/core/src/interactionMode/ClickArrowToExpandInteractionManager.ts
@@ -27,7 +27,7 @@ export class ClickArrowToExpandInteractionManager implements InteractionManager 
         actions.focusItem();
         if (e.shiftKey) {
           actions.selectUpTo();
-        } else if (e.ctrlKey) {
+        } else if (e.ctrlKey || e.metaKey) {
           if (renderFlags.isSelected) {
             actions.unselectItem();
           } else {

--- a/packages/core/src/interactionMode/ClickItemToExpandInteractionManager.ts
+++ b/packages/core/src/interactionMode/ClickItemToExpandInteractionManager.ts
@@ -27,7 +27,7 @@ export class ClickItemToExpandInteractionManager implements InteractionManager {
         actions.focusItem();
         if (e.shiftKey) {
           actions.selectUpTo();
-        } else if (e.ctrlKey) {
+        } else if (e.ctrlKey || e.metaKey) {
           if (renderFlags.isSelected) {
             actions.unselectItem();
           } else {

--- a/packages/core/src/interactionMode/DoubleClickItemToExpandInteractionManager.ts
+++ b/packages/core/src/interactionMode/DoubleClickItemToExpandInteractionManager.ts
@@ -27,7 +27,7 @@ export class DoubleClickItemToExpandInteractionManager implements InteractionMan
         actions.focusItem();
         if (e.shiftKey) {
           actions.selectUpTo();
-        } else if (e.ctrlKey) {
+        } else if (e.ctrlKey || e.metaKey) {
           if (renderFlags.isSelected) {
             actions.unselectItem();
           } else {


### PR DESCRIPTION
Allows using the meta key or control key in scenarios where only the control key could be used for multi-selection. This lets Mac users perform non-contiguous multi-selection, which resolves issue #80.