### PR TITLE
Bug fix: Folder disappeared when trying to drop it inside of itself. 

### DIFF
--- a/packages/core/src/uncontrolledEnvironment/UncontrolledTreeEnvironment.tsx
+++ b/packages/core/src/uncontrolledEnvironment/UncontrolledTreeEnvironment.tsx
@@ -153,6 +153,11 @@ export const UncontrolledTreeEnvironment = React.forwardRef<
               child => child !== item.index
             );
 
+             if (target.parentItem === item.index) {
+              // Trying to drop inside itself
+              return;
+            }
+
             if (target.parentItem === parent.index) {
               const isOldItemPriorToNewItem =
                 ((newParent.children ?? []).findIndex(


### PR DESCRIPTION
Current behavior  is erratic: When a folder is expanded and the user drags the folder into itself the folder disappears. To prevent this I added a quick check for current item index being equal to parent index.