### PR TITLE
Fix drag-drop position not updating

### DIFF
--- a/packages/core/src/controlledEnvironment/useOnDragOverTreeHandler.ts
+++ b/packages/core/src/controlledEnvironment/useOnDragOverTreeHandler.ts
@@ -213,6 +213,7 @@ export const useOnDragOverTreeHandler = (
           draggingItem => draggingItem.index === targetItem.item
         )
       ) {
+        onDragAtPosition(undefined);
         return;
       }
 


### PR DESCRIPTION
Right now if you drag an item on top of the folder above it, then drag it back to its initial position, the folder above will stay highlighted and if you drop the item it will get put into that folder even though you're no longer hovering above it. This can be seen here: https://rct.lukasbach.com/storybook/?path=/story/core-drag-and-drop-configurability--no-reordering-allowed.


https://user-images.githubusercontent.com/122892706/230478615-eabf97a8-0f2b-4416-91b4-cdf7e1db88b3.mov



