### PR TITLE
feat: expose `depth` and `parentId` to `renderItemsContainer`

### DIFF
--- a/packages/core/src/treeItem/TreeItemChildren.tsx
+++ b/packages/core/src/treeItem/TreeItemChildren.tsx
@@ -30,5 +30,7 @@ export const TreeItemChildren = (props: {
     children: childElements,
     info: treeInformation,
     containerProps,
+    depth: props.depth,
+    parentId: props.parentId,
   }) as any;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -114,6 +114,8 @@ export interface TreeRenderProps<T = any, C extends string = never> {
     children: React.ReactNode;
     containerProps: HTMLProps<any>;
     info: TreeInformation;
+    depth: number;
+    parentId: TreeItemIndex;
   }) => React.ReactElement | null;
 
   renderTreeContainer?: (props: {


### PR DESCRIPTION
<!-- Please assign @lukasbach as reviewer to this PR. Otherwise I might miss it. -->

This PR forwards the `parentId` prop and `depth` prop to `renderItemsContainer`. 

My use case is that I need to render a text input at each level of the tree to allow creating values at that level.
Having access to the `depth` prop allows me to render the input component at the proper level of indentation. The `parentId` is needed so I know where to push the new item :) 

![Screenshot 2023-05-16 at 17 50 55](https://github.com/lukasbach/react-complex-tree/assets/1866649/ef5cc620-d904-42ca-ba19-77bf6cdacdd3)

@lukasbach I cannot assign reviewers, but hopefully a mention is enough of a nudge 😄 