### PR TITLE
fix LiveDescriptors doc comment

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -445,9 +445,9 @@ export interface KeyboardBindings {
  * Live descriptors are written in an aria live region describing the state of the
  * tree to accessibility readers. They are displayed in a visually hidden area at the
  * bottom of the tree. Each descriptor composes a HTML string. Variables in the form
- * of {variableName} can be used.
+ * of \{variableName\} can be used.
  *
- * The {keybinding:bindingname} variable referns to a specific keybinding, i.e. {keybinding:primaryAction}
+ * The \{keybinding:bindingname\} variable refers to a specific keybinding, i.e. \{keybinding:primaryAction\}
  * is a valid variable.
  *
  * See the implementation of the `defaultLiveDescriptors` for more details.


### PR DESCRIPTION
Escape curly braces and fix spelling error.

Fixes the following warnings:

    react-complex-tree/packages/core/src/types.ts:448:6 - warning Encountered an unescaped open brace without an inline tag
    448     * of {variableName} can be used.
    react-complex-tree/packages/core/src/types.ts:448:19 - warning Unmatched closing brace
    448     * of {variableName} can be used.
    react-complex-tree/packages/core/src/types.ts:450:7 - warning Encountered an unescaped open brace without an inline tag
    450     * The {keybinding:bindingname} variable referns to a specific keybinding, i.e. {keybinding:primaryAction}
    react-complex-tree/packages/core/src/types.ts:450:30 - warning Unmatched closing brace
    450     * The {keybinding:bindingname} variable referns to a specific keybinding, i.e. {keybinding:primaryAction}
    react-complex-tree/packages/core/src/types.ts:450:80 - warning Encountered an unescaped open brace without an inline tag
    450     * The {keybinding:bindingname} variable referns to a specific keybinding, i.e. {keybinding:primaryAction}
    react-complex-tree/packages/core/src/types.ts:450:105 - warning Unmatched closing brace
    450     * The {keybinding:bindingname} variable referns to a specific keybinding, i.e. {keybinding:primaryAction}

Solves #TODO <!-- please add a ticket number if available -->

<!-- Description of changes -->

<!--
Please also make sure to update the /next-release-notes.md file with a bullet point of your change, for example

  ### Bug Fixes and Improvements
  - Fixes a bug where XXX is happening in YYY condition (#ticket-number)
-->

@lukasbach
