### PR TITLE
Fix: Syntax error in closing tag in documentation

### DIFF
--- a/packages/docs/docs/guides/rendering.mdx
+++ b/packages/docs/docs/guides/rendering.mdx
@@ -119,7 +119,7 @@ renderItem={({ title, arrow, depth, context, children }) => (
       </button>
     </li>
     {children}
-  <>
+  </>
 )}
 ```
 


### PR DESCRIPTION
### Bug Fixes and Improvements
- Fixed syntax error in closing tag in documentation