### PR TITLE
Fix: docs typo

### DIFF
--- a/packages/docs/docs/guides/renaming.mdx
+++ b/packages/docs/docs/guides/renaming.mdx
@@ -4,7 +4,7 @@ sidebar_position: 7
 
 # Renaming Functionality
 
-React Complex Tree provides native renaming capabilities which are enabled by default. They an be disabled
+React Complex Tree provides native renaming capabilities which are enabled by default. They can be disabled
 by providing the `canRename` prop with the value `false`.
 
 If renaming is enabled, the user can hit the hotkey `F2`, and the title component of the focused item


### PR DESCRIPTION
Fix small typo in the docs