### PR TITLE
made item height for drag position dynamic

### DIFF
--- a/packages/core/src/controlledEnvironment/layoutUtils.ts
+++ b/packages/core/src/controlledEnvironment/layoutUtils.ts
@@ -7,6 +7,19 @@ export const computeItemHeight = (treeId: string) => {
   return firstItem?.offsetHeight ?? 5;
 };
 
+export const computeItemHeightArray = (treeId: string): number[] => {
+  const document = getDocument();
+  if (!document) {
+    console.log("Document not found");
+    return [];
+  }
+  const items = document.querySelectorAll<HTMLElement>(`[data-rct-tree="${treeId}"] [data-rct-item-container="true"]`);
+  const itemHeights = Array.from(items).map(item => item.offsetHeight);
+
+  console.log({ itemHeights });
+  return itemHeights;
+};
+
 export const isOutsideOfContainer = (e: DragEvent, treeBb: DOMRect) =>
   e.clientX < treeBb.left ||
   e.clientX > treeBb.right ||

--- a/packages/core/src/drag/DragAndDropProvider.tsx
+++ b/packages/core/src/drag/DragAndDropProvider.tsx
@@ -41,6 +41,7 @@ export const DragAndDropProvider: React.FC<React.PropsWithChildren> = ({
     draggingItems,
     getDraggingPosition,
     itemHeight,
+    itemsHeightArray,
   } = useDraggingPosition();
 
   const resetProgrammaticDragIndexForCurrentTree = useCallback(
@@ -285,6 +286,7 @@ export const DragAndDropProvider: React.FC<React.PropsWithChildren> = ({
       draggingItems,
       draggingPosition,
       itemHeight: itemHeight.current,
+      itemsHeightArray: itemsHeightArray.current,
       isProgrammaticallyDragging,
       onDragOverTreeHandler,
       viableDragPositions,
@@ -296,6 +298,7 @@ export const DragAndDropProvider: React.FC<React.PropsWithChildren> = ({
       draggingPosition,
       isProgrammaticallyDragging,
       itemHeight,
+      itemsHeightArray,
       onDragOverTreeHandler,
       onStartDraggingItems,
       programmaticDragDown,

--- a/packages/core/src/tree/DragBetweenLine.tsx
+++ b/packages/core/src/tree/DragBetweenLine.tsx
@@ -6,7 +6,7 @@ import { useDragAndDrop } from '../drag/DragAndDropProvider';
 export const DragBetweenLine: React.FC<{
   treeId: string;
 }> = ({ treeId }) => {
-  const { draggingPosition, itemHeight } = useDragAndDrop();
+  const { draggingPosition, itemHeight, itemsHeightArray } = useDragAndDrop();
   const { renderers } = useTree();
 
   const shouldDisplay =
@@ -28,7 +28,7 @@ export const DragBetweenLine: React.FC<{
         position: 'absolute',
         left: '0',
         right: '0',
-        top: `${(draggingPosition?.linearIndex ?? 0) * itemHeight}px`,
+        top: `${itemsHeightArray.slice(0, draggingPosition?.linearIndex ?? 0).reduce((acc, height) => acc + height, 0)}px`,
       }}
     >
       {renderers.renderDragBetweenLine({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -312,6 +312,7 @@ export interface DragAndDropContextProps<T = any> {
   onStartDraggingItems: (items: TreeItem<T>[], treeId: string) => void;
   draggingItems?: TreeItem<T>[];
   itemHeight: number;
+  itemsHeightArray: number[];
   isProgrammaticallyDragging?: boolean;
   startProgrammaticDrag: () => void;
   abortProgrammaticDrag: () => void;

--- a/packages/docs/docs/guides/multiple-trees.mdx
+++ b/packages/docs/docs/guides/multiple-trees.mdx
@@ -70,8 +70,6 @@ still show different contents.
   canDragAndDrop={true}
   canDropOnFolder={true}
   canReorderItems={true}
-  renderItemTitle={({ title }) => <div style={{wordBreak: 'break-all', display:'flex', whiteSpace: 'break-spaces !important', width: 50, height:'100% !important' }}>
-      {title} {title} {title} {title} </div>}
   dataProvider={new StaticTreeDataProvider(longTree.items, (item, data) => ({ ...item, data }))}
   getItemTitle={item => item.data}
   viewState={{}}

--- a/packages/docs/docs/guides/multiple-trees.mdx
+++ b/packages/docs/docs/guides/multiple-trees.mdx
@@ -70,6 +70,8 @@ still show different contents.
   canDragAndDrop={true}
   canDropOnFolder={true}
   canReorderItems={true}
+  renderItemTitle={({ title }) => <div style={{wordBreak: 'break-all', display:'flex', whiteSpace: 'break-spaces !important', width: 50, height:'100% !important' }}>
+      {title} {title} {title} {title} </div>}
   dataProvider={new StaticTreeDataProvider(longTree.items, (item, data) => ({ ...item, data }))}
   getItemTitle={item => item.data}
   viewState={{}}


### PR DESCRIPTION
Solves #338 

added itemsHeightArray to replace ItemHeight and refactored the code using this new const to make the drag and drop functions use a dynamic height of each tree's exact items instead using the static height of the first item then multiplying it as they had with itemHeight. I didn't delete itemHeight in case any function uses it, but likely nothing uses it.

  ### Bug Fixes and Improvements
  - Fixes a bug where drag positions would be off and not work properly when you make trees have different heights for each item or each item has different heights (#338)


@austinmkerr
