### PR TITLE
Fix problem with expandSubsequently resolving before expanding all items

### DIFF
--- a/next-release-notes.md
+++ b/next-release-notes.md
@@ -4,6 +4,6 @@
 ### Features
 
 ### Bug Fixes and Improvements
-
+- Fix problem with expandSubsequently resolving before expanding all items
 ### Other Changes
 -->

--- a/packages/core/src/environmentActions/EnvironmentActionsProvider.tsx
+++ b/packages/core/src/environmentActions/EnvironmentActionsProvider.tsx
@@ -177,10 +177,13 @@ export const EnvironmentActionsProvider = React.forwardRef<
       await waitFor(() => !!itemsRef.current?.[current]).then(() => {
         const item = itemsRef.current[current];
         if (!item) {
-          return;
+          return Promise.resolve();
         }
         onExpandItem?.(item, treeId);
-        expandSubsequently(treeId, rest);
+        if (rest.length > 0) {
+          return expandSubsequently(treeId, rest);
+        }
+        return Promise.resolve();
       });
     },
     [itemsRef, onExpandItem]


### PR DESCRIPTION
Issue solved:
`expandSubsequently` does not wait to expand all items provided in argument. In rare cases it leads to errors.

Additional info:
1. Tests are failing for some reason but they are failing even without my changes (locally)
2. This is fixing a lot of problems but not all - e.g. in your story (https://rct.lukasbach.com/storybook/?path=/story/core-finding-items--custom-finder) after typing `pizza` you will get error `Cannot read properties of undefined (reading 'index')` this is similar to error that I was getting but my fix is not addressing that because `Europe` item is not expanded before this function resolves - this is because `onExpandItem` is not returning promise so I can't wait for it.

@lukasbach