### PR TITLE
feat: #258 Loosing registered tree affecting drag and drop between different trees.

### DIFF
--- a/next-release-notes.md
+++ b/next-release-notes.md
@@ -4,6 +4,7 @@
 ### Features
 
 ### Bug Fixes and Improvements
+- Fixes an issue where drag and drop between trees was not working after remount of the target tree(#258)
 
 ### Other Changes
 -->

--- a/packages/core/src/controlledEnvironment/useControlledTreeEnvironmentProps.ts
+++ b/packages/core/src/controlledEnvironment/useControlledTreeEnvironmentProps.ts
@@ -88,8 +88,11 @@ export const useControlledTreeEnvironmentProps = ({
   const unregisterTree = useCallback(
     treeId => {
       onUnregisterTree?.(trees[treeId]);
-      delete trees[treeId];
-      setTrees(trees);
+      setTrees(trees => {
+        const newTrees = {...trees};
+        delete newTrees[treeId];
+        return newTrees;
+      });
     },
     [onUnregisterTree, trees]
   );

--- a/packages/core/src/controlledEnvironment/useControlledTreeEnvironmentProps.ts
+++ b/packages/core/src/controlledEnvironment/useControlledTreeEnvironmentProps.ts
@@ -89,7 +89,7 @@ export const useControlledTreeEnvironmentProps = ({
     treeId => {
       onUnregisterTree?.(trees[treeId]);
       setTrees(trees => {
-        const newTrees = {...trees};
+        const newTrees = { ...trees };
         delete newTrees[treeId];
         return newTrees;
       });


### PR DESCRIPTION
Using the updater function for setting new value for trees to avoid an issue in dragging items between trees.
Loosing the registered tree if it unmounted and mounted.

Solves issue: #258 

Using the updater function for setting new value for trees

<!--
Please also make sure to update the /next-release-notes.md file with a bullet point of your change, for example

  ### Bug Fixes and Improvements
  - Fixes a bug where XXX is happening in YYY condition (#ticket-number)
-->

@lukasbach
